### PR TITLE
Avoid using `example` as a cmake target

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,9 +26,9 @@ jobs:
       - name: Build
         run: |
           cmake --build .build --config Release
-          cmake --build .build --config Release --target example
+          cmake --build .build --config Release --target libviper_example
       - name: Test
         working-directory: ${{ github.workspace }}/.build
         run: |
           ctest -C Release
-          ./example/example
+          ./example/libviper_example

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,13 +1,13 @@
-add_executable(example EXCLUDE_FROM_ALL
+add_executable(${PROJECT_NAME}_example EXCLUDE_FROM_ALL
 	main.cpp
 )
 
 cmake_path(SET example_conf_path ${CMAKE_CURRENT_SOURCE_DIR}/conf)
-target_compile_definitions(example
+target_compile_definitions(${PROJECT_NAME}_example
 	PRIVATE EXAMPLE_CONF_PATH="${example_conf_path}"
 )
 
-target_link_libraries(example
+target_link_libraries(${PROJECT_NAME}_example
 	PRIVATE libviper::viper
 )
 


### PR DESCRIPTION
`example` is a common target name (`zlib` has the same) and this conflicts when used with `FetchContent_Declare()`. 