### PR TITLE
Convenience constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ A library for reading configs built using modern c++ standards.
 ```c++
 #include <viper/config.h>
 
-// A config can be constructed by passing in a config name (without the file extension) and a path to
-// look for config files.
-auto conf = viper::config("config.name", "/path/to/config/files");
+// A config can be constructed by passing in a config name (without the file extension)
+// and optionally a path to look for config files.
+auto conf = viper::config("config.name", std::filesystem::current_path() / "conf");
+// auto conf = viper::config("config.name", "/path/to/config/files");
+// auto conf = viper::config("config.name"); // Looks for configs in the current working directory
 
 // Reading configs can throw exceptions
 try {
@@ -35,8 +37,8 @@ try {
 }
 
 // Config values can be retrieved using a key path (`.` can be used to drill down into maps)
-// Note: this will look for an environment variable with key PATH_TO_KEY and if set, return the env value
-//       instead of the value from config file.
+// Note: this will look for an environment variable with key PATH_TO_KEY and if set, return
+//       the env value instead of the value from config file.
 viper::value v = conf["path.to.key"];
 
 // Convert to scalar/basic types using explicit conversions

--- a/lib/viper/config.cpp
+++ b/lib/viper/config.cpp
@@ -11,6 +11,8 @@
 namespace viper {
 config::config(const char *name, const char *path) : _name(name), _path(path) {}
 
+config::config(const char *name, std::filesystem::path path) : _name(name), _path(path) {}
+
 config::config(tree_t t) : _tree(t) {}
 
 std::filesystem::path config::filename() {
@@ -18,7 +20,7 @@ std::filesystem::path config::filename() {
 		return _filename;
 	}
 
-	auto fpath = std::filesystem::path(_path) / "";
+	auto fpath = _path / "";
 	for (const auto &ext : extensions) {
 		auto fname = std::filesystem::path(_name);
 		fname += ext;

--- a/lib/viper/config.h
+++ b/lib/viper/config.h
@@ -58,9 +58,9 @@ public:
 	viper::value val(const char *path) const noexcept;
 
 private:
-	const char           *_name;
-	std::filesystem::path _path;
+	const char *_name;
 
+	std::filesystem::path _path;
 	std::filesystem::path _filename;
 
 	tree_t _tree;

--- a/lib/viper/config.h
+++ b/lib/viper/config.h
@@ -21,7 +21,8 @@ public:
 	typedef ryml::NodeRef node_t;
 
 	config() = delete;
-	config(const char *name, const char *path = "./");
+	config(const char *name, const char *path);
+	config(const char *name, std::filesystem::path path = std::filesystem::current_path());
 	config(tree_t t);
 
 	inline viper::value operator[](const char *key) const { return get(key); }
@@ -57,8 +58,8 @@ public:
 	viper::value val(const char *path) const noexcept;
 
 private:
-	const char *_name;
-	const char *_path;
+	const char           *_name;
+	std::filesystem::path _path;
 
 	std::filesystem::path _filename;
 

--- a/lib/viper/config_test.cpp
+++ b/lib/viper/config_test.cpp
@@ -63,7 +63,7 @@ TEST(viper, config_filename) {
 
 	// Non-existent configs
 	{
-		auto c = viper::config("non-existent", VIPER_TESTDATA_PATH);
+		auto c = viper::config("non-existent");
 		EXPECT_TRUE(c.filename().empty());
 	}
 }


### PR DESCRIPTION
Allow using `std::filesystem::path` for config path when constructing configs.